### PR TITLE
Set nullglob option

### DIFF
--- a/import_to_rc.zsh
+++ b/import_to_rc.zsh
@@ -5,6 +5,9 @@
 # Author: David Kasabji
 # Date: 2024-11-06
 
+# Treat umatched globs as empty lists
+setopt nullglob
+
 # Color codes for output formatting
 COL_BLUE='\x1b[34m'
 COL_CYAN='\x1b[36m'


### PR DESCRIPTION
This change tells Zsh to treat unmatched glob patterns as empty lists rather than errors, allowing the script to continue even when it doesn't find any matching UUID profile directories.

Had to add this to get the script to work, as I was getting this error:

```
./import_to_rc.zsh:112: no matches found: /Users/nick/Library/Application Support/Orion/*-*-*-*-*
```